### PR TITLE
:ambulance: Remove channel_id from conclude_dispute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,12 +348,9 @@ pub mod pallet {
 		/// a finalized state is provided and signed by all participants.
 		///
 		/// Emits an [Event::Concluded] event on success.
-		pub fn conclude_dispute(
-			origin: OriginFor<T>,
-			params: ParamsOf<T>,
-			channel_id: ChannelIdOf<T>,
-		) -> DispatchResult {
+		pub fn conclude_dispute(origin: OriginFor<T>, params: ParamsOf<T>) -> DispatchResult {
 			ensure_signed(origin)?;
+			let channel_id = params.channel_id::<T::Hasher>();
 
 			match <StateRegister<T>>::get(&channel_id) {
 				Some(dispute) => {

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -111,7 +111,7 @@ fn unsigned_tx() {
 	});
 	run_test(|_| {
 		assert_noop!(
-			Perun::conclude_dispute(Origin::none(), Default::default(), Default::default()),
+			Perun::conclude_dispute(Origin::none(), Default::default()),
 			BadOrigin
 		);
 	});


### PR DESCRIPTION
Security relevant change to calculate the `channel_id` from the passed params instead of also passing it.  
This check must have gone missing after some of the refactors :see_no_evil:  
Adds a test so that wrong participants can not `conclude_final`.