### PR TITLE
Remove 'Open issues' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,16 +76,6 @@ cargo doc --no-deps --open --package pallet-perun
 The development of this project is supported by the [Web3 Foundation] through the [Open Grants Program].  
 The development of the go-perun library is supported by the German Ministry of Education and Science (BMBF) through a Startup Secure grant.
 
-## Open issues
-
-Some points that we want to take a closer look at in the future:
-
-- Add codecov once the repo is public.
-- Only one currency can currently be used per channel. Multi-Currency channels are supported by *go-perun*. Having them here would be nice too.
-- Find out if it is dangerous to have state-modifying functions in not-`#[pallet::call]` functions.
-- Add reasonable weight estimations.
-- It is possible to dispute unfunded channels. This could be used to inflate the on-chain state.
-
 ## Security Disclaimer
 
 This software is still under development.


### PR DESCRIPTION
Added issues #10 and #11.  
The MultiAsset is omitted since it is not an 'issue' but more of a future feature.  
I checked the state modification in not-`#[pallet::call]` functions; They are not exposed to the user and therefore safe to modify the state.

Closes #9