### PR TITLE
Allow progression beyond timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,8 +184,6 @@ pub mod pallet {
 		RegisterPhaseOver,
 		/// The operation is potentially valid but too early.
 		TooEarly,
-		/// The operation is not valid anymore.
-		TooLate,
 		/// The operation is invalid because the channel is already concluded.
 		AlreadyConcluded,
 		/// The dispute timeout did not yet elapse.
@@ -363,12 +361,12 @@ pub mod pallet {
 			let channel_id = next.channel_id;
 			match <StateRegister<T>>::get(channel_id) {
 				Some(dispute) => {
-					// Ensure correct phase. Either after registration or before
-					// end of progression.
+					// Ensure correct phase. Must be after dispute timeout and not
+					// concluded.
 					let now = Self::now();
 					match dispute.phase {
 						Phase::Register => ensure!(now >= dispute.timeout, Error::<T>::TooEarly),
-						Phase::Progress => ensure!(now < dispute.timeout, Error::<T>::TooLate),
+						Phase::Progress => {}
 						Phase::Conclude => return Err(Error::<T>::AlreadyConcluded.into()),
 					}
 

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -253,46 +253,6 @@ fn progress_too_early() {
 }
 
 #[test]
-fn progress_too_late() {
-	run_test(MOCK_APP, |setup| {
-		deposit_both(&setup);
-		call_dispute(&setup, false);
-
-		increment_time(setup.params.challenge_duration);
-
-		let mut state = setup.state.clone();
-		state.version += 1;
-		state.data = MOCK_DATA_VALID.to_vec();
-		let sigs = sign_state(&state, &setup);
-		let signer = 0;
-
-		assert_ok!(Perun::progress(
-			Origin::signed(setup.ids.alice),
-			setup.params.clone(),
-			state.clone(),
-			sigs[signer].clone(),
-			signer.try_into().unwrap(),
-		));
-		assert_event_progressed(state.channel_id, state.version, setup.params.app);
-
-		increment_time(setup.params.challenge_duration);
-
-		state.version += 1;
-		let sigs = sign_state(&state, &setup);
-		assert_noop!(
-			Perun::progress(
-				Origin::signed(setup.ids.alice),
-				setup.params.clone(),
-				state.clone(),
-				sigs[signer].clone(),
-				signer.try_into().unwrap(),
-			),
-			pallet_perun::Error::<Test>::TooLate
-		);
-	});
-}
-
-#[test]
 fn progress_already_concluded() {
 	run_test(MOCK_APP, |setup| {
 		deposit_both(&setup);


### PR DESCRIPTION
The timeout indicates when a channel can be concluded. However, we can be more permissive in terms of how long we allow on-chain progression. If the channel is not concluded yet, we can still act.

Depends on #21 