### PR TITLE
feat: update substrate sdk version to polkadot v1.9

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,5 +143,6 @@ jobs:
       - name: CodeCov upload
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: "${{ env.KCOV_OUT }}/merged"
           fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,14 +17,14 @@ jobs:
       KCOV_OUT: "target/cov/pallet_perun"
       KCOV: "~/cache/usr/local/bin/kcov"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2  # CodeCov needs this
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         name: Setup Cache
 
       - uses: actions-rs/cargo@v1
@@ -64,7 +64,7 @@ jobs:
           args: --all-targets --all-features
 
       - name: kcov cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/cache
           key: ${{ runner.os }}-kcov-wget
@@ -141,7 +141,7 @@ jobs:
           $KCOV --merge "$KCOV_OUT/merged" "$KCOV_OUT"/unmerged-*
 
       - name: CodeCov upload
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           directory: "${{ env.KCOV_OUT }}/merged"
           fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["blockchain", "channel", "perun"]
 repository = "https://github.com/perun-network/perun-polkadot-pallet"
 description = "FRAME pallet for Perun State Channels"
 readme = "README.md"
-edition.workspace = true
+edition = "2021"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 ] }
 scale-info = { version = "2.10.0", default-features = false, features = [
 	"derive",
-] }
-syn = "=1.0.109"  
+] } 
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,37 +1,43 @@
 [package]
 name = "pallet-perun"
-version = "4.0.0-dev"
 authors = ["PolyCrypt GmbH <info@polycry.pt>"]
-edition = "2018"
 license = "Apache-2.0"
+version = "0.0.0"
 homepage = "https://polycry.pt/"
 keywords = ["blockchain", "channel", "perun"]
 repository = "https://github.com/perun-network/perun-polkadot-pallet"
 description = "FRAME pallet for Perun State Channels"
 readme = "README.md"
+edition.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
-sp-runtime = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
-sp-std = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
-sp-io = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0",  default-features = false  }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0",  default-features = false  }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0",  default-features = false  }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0",  default-features = false  }
 
-frame-support = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
-frame-system = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
-frame-benchmarking = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1', optional=true}
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0", default-features = false, optional = true }
 
-pallet-balances = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
-pallet-timestamp = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0", default-features = false }
 
-codec = {package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"]}
-syn = "=1.0.76"
+codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+	"derive",
+] }
+scale-info = { version = "2.10.0", default-features = false, features = [
+	"derive",
+] }
+syn = "=1.0.109"  
 
 [dev-dependencies]
-sp-io = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
-sp-runtime = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1'}
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0" }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.9.0" }
 
 
 [features]
@@ -39,16 +45,26 @@ default = ["std"]
 # Used for testing only.
 expose_privates = []
 # Enable Benchmarks.
-runtime-benchmarks = ['frame-benchmarking']
+runtime-benchmarks = [
+  "frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+]
 std = [
   "codec/std",
+  "sp-core/std",
   "sp-std/std",
   "sp-io/std",
   "sp-runtime/std",
-  "frame-benchmarking/std",
+  "frame-benchmarking?/std",
   "frame-support/std",
   "frame-system/std",
   "pallet-balances/std",
   "pallet-timestamp/std",
 ]
-try-runtime = ['frame-support/try-runtime']
+try-runtime = [
+  "frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"sp-runtime/try-runtime",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{ensure_signed, pallet_prelude::*};
-use sp_runtime::traits::{ AccountIdConversion, CheckedAdd, IdentifyAccount, Verify };
+use sp_runtime::traits::{AccountIdConversion, CheckedAdd, IdentifyAccount, Verify};
 use sp_std::{cmp, convert::TryFrom, ops::Range, vec::Vec};
 
 macro_rules! require {
@@ -61,7 +61,7 @@ pub mod pallet {
 		traits::{ExistenceRequirement, Get},
 	};
 	use sp_core::ByteArray;
-use sp_runtime::traits::{CheckedAdd, Member};
+	use sp_runtime::traits::{CheckedAdd, Member};
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_timestamp::Config {
@@ -106,7 +106,12 @@ use sp_runtime::traits::{CheckedAdd, Member};
 		/// Must be possible to verify that a [Config::PK] created a signature.
 		type Signature: Encode + Decode + Member + TypeInfo + Verify<Signer = Self::PK>;
 		/// PK of a [Config::Signature].
-		type PK: Encode + Decode + Member + ByteArray + TypeInfo + IdentifyAccount<AccountId = Self::PK>;
+		type PK: Encode
+			+ Decode
+			+ Member
+			+ ByteArray
+			+ TypeInfo
+			+ IdentifyAccount<AccountId = Self::PK>;
 
 		/// Represent a time duration in seconds.
 		type Seconds: FullCodec + Member + TypeInfo + CheckedAdd + PartialOrd + From<u64>;
@@ -243,7 +248,7 @@ use sp_runtime::traits::{CheckedAdd, Member};
 		///
 		/// Emits an [Event::Deposited] event on success.
 		#[pallet::weight(WeightInfoOf::<T>::deposit())]
-        #[pallet::call_index(0)]
+		#[pallet::call_index(0)]
 		pub fn deposit(
 			origin: OriginFor<T>,
 			funding_id: FundingIdOf<T>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -200,7 +200,7 @@ where
 
 		Self {
 			channel_id: ChannelId::default(),
-			part: part,
+			part,
 			receiver: AccountId::default(),
 		}
 	}
@@ -226,7 +226,7 @@ where
 
 	pub fn has_app<T: Config<AppId = AppId>>(&self) -> bool {
 		let no_app = T::NoApp::get();
-		return self.app != no_app;
+		self.app != no_app
 	}
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,9 +16,9 @@
 
 use crate::*;
 
+use crate::pallet::Config;
 use codec::{Decode, Encode};
 use sp_core::{ByteArray, Hasher};
-use crate::pallet::Config;
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
 	RuntimeDebug,
@@ -86,20 +86,19 @@ pub struct Params<Nonce, PK, Seconds, AppId> {
 impl<Nonce, PK, Seconds, AppId> Default for Params<Nonce, PK, Seconds, AppId>
 where
 	Nonce: Default,
-    Vec<PK>: Default, // This is crucial for initializing an empty vector of PK
-    Seconds: Default,
-    AppId: Default,
+	Vec<PK>: Default, // This is crucial for initializing an empty vector of PK
+	Seconds: Default,
+	AppId: Default,
 {
-    fn default() -> Self {
-        Self {
-            nonce: Nonce::default(),
-            participants: Vec::default(), // Initialize an empty vector of PK
-            challenge_duration: Seconds::default(),
-            app: AppId::default(),
-        }
-    }
+	fn default() -> Self {
+		Self {
+			nonce: Nonce::default(),
+			participants: Vec::default(), // Initialize an empty vector of PK
+			challenge_duration: Seconds::default(),
+			app: AppId::default(),
+		}
+	}
 }
-
 
 #[derive(Encode, Decode, Default, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 #[codec(dumb_trait_bound)]
@@ -181,32 +180,31 @@ pub struct Withdrawal<ChannelId, PK, AccountId> {
 
 impl<ChannelId, PK, AccountId> Default for Withdrawal<ChannelId, PK, AccountId>
 where
-    ChannelId: Default,
+	ChannelId: Default,
 	PK: ByteArray + MaxEncodedLen,
-    AccountId: Default,
+	AccountId: Default,
 {
-    fn default() -> Self {
+	fn default() -> Self {
 		let array_len = PK::max_encoded_len();
 		// Create a zero-initialized byte array of the appropriate length
 		let zero_array = vec![0u8; array_len];
 
-        // Attempt to create a `PK` instance from the zero-initialized byte array
-        let part = match PK::from_slice(&zero_array) {
-            Ok(part) => part,
-            Err(_) => {
-                // If creation fails, handle the error (e.g., log an error message or panic)
-                panic!("Error creating PK instance from zero-initialized array");
-            }
-        };
+		// Attempt to create a `PK` instance from the zero-initialized byte array
+		let part = match PK::from_slice(&zero_array) {
+			Ok(part) => part,
+			Err(_) => {
+				// If creation fails, handle the error (e.g., log an error message or panic)
+				panic!("Error creating PK instance from zero-initialized array");
+			}
+		};
 
-        Self {
-            channel_id: ChannelId::default(),
-            part: part,
-            receiver: AccountId::default(),
-        }
-    }
+		Self {
+			channel_id: ChannelId::default(),
+			part: part,
+			receiver: AccountId::default(),
+		}
+	}
 }
-
 
 #[derive(Encode, Decode, Default, Copy, Clone, PartialEq, RuntimeDebug)]
 #[codec(dumb_trait_bound)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,8 @@
 use crate::*;
 
 use codec::{Decode, Encode};
-use sp_core::Hasher;
+use sp_core::{ByteArray, Hasher};
+use crate::pallet::Config;
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
 	RuntimeDebug,
@@ -49,8 +50,8 @@ pub type FundingOf<T> = Funding<ChannelIdOf<T>, PkOf<T>>;
 pub type AppIdOf<T> = <T as Config>::AppId;
 pub type AppData = Vec<u8>;
 
-pub trait AppId: Encode + Decode + Member + PartialEq {}
-impl<T: Encode + Decode + Member + PartialEq> AppId for T {}
+pub trait AppId: Encode + Decode + TypeInfo + Member + PartialEq {}
+impl<T: Encode + Decode + TypeInfo + Member + PartialEq> AppId for T {}
 
 pub trait AppRegistry<T: pallet::Config> {
 	fn valid_transition(
@@ -63,7 +64,7 @@ pub trait AppRegistry<T: pallet::Config> {
 	fn transition_weight(params: &ParamsOf<T>) -> Weight;
 }
 
-#[derive(Encode, Decode, Default, Clone, PartialEq, RuntimeDebug)]
+#[derive(Encode, Decode, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 #[codec(dumb_trait_bound)]
 /// Fixed parameters of a channel.
 ///
@@ -82,7 +83,25 @@ pub struct Params<Nonce, PK, Seconds, AppId> {
 	pub app: AppId,
 }
 
-#[derive(Encode, Decode, Default, Clone, PartialEq, RuntimeDebug)]
+impl<Nonce, PK, Seconds, AppId> Default for Params<Nonce, PK, Seconds, AppId>
+where
+	Nonce: Default,
+    Vec<PK>: Default, // This is crucial for initializing an empty vector of PK
+    Seconds: Default,
+    AppId: Default,
+{
+    fn default() -> Self {
+        Self {
+            nonce: Nonce::default(),
+            participants: Vec::default(), // Initialize an empty vector of PK
+            challenge_duration: Seconds::default(),
+            app: AppId::default(),
+        }
+    }
+}
+
+
+#[derive(Encode, Decode, Default, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 #[codec(dumb_trait_bound)]
 /// Off-Chain state of a channel.
 pub struct State<ChannelId, Version, Balance> {
@@ -116,14 +135,14 @@ pub struct State<ChannelId, Version, Balance> {
 	pub data: AppData,
 }
 
-#[derive(Encode, Decode, Copy, Clone, PartialEq, RuntimeDebug)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 pub enum Phase {
 	Register,
 	Progress,
 	Conclude,
 }
 
-#[derive(Encode, Decode, Copy, Clone, PartialEq, RuntimeDebug)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 #[codec(dumb_trait_bound)]
 /// Off-chain [State] that was registered on-chain.
 ///
@@ -141,7 +160,7 @@ pub struct RegisteredState<State, Seconds> {
 	pub timeout: Seconds,
 }
 
-#[derive(Encode, Decode, Default, Copy, Clone, PartialEq, RuntimeDebug)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, RuntimeDebug, TypeInfo)]
 #[codec(dumb_trait_bound)]
 /// Withdrawal authorization for on-chain funds.
 ///
@@ -159,6 +178,35 @@ pub struct Withdrawal<ChannelId, PK, AccountId> {
 	/// On-Chain Account to credited.
 	pub receiver: AccountId,
 }
+
+impl<ChannelId, PK, AccountId> Default for Withdrawal<ChannelId, PK, AccountId>
+where
+    ChannelId: Default,
+	PK: ByteArray + MaxEncodedLen,
+    AccountId: Default,
+{
+    fn default() -> Self {
+		let array_len = PK::max_encoded_len();
+		// Create a zero-initialized byte array of the appropriate length
+		let zero_array = vec![0u8; array_len];
+
+        // Attempt to create a `PK` instance from the zero-initialized byte array
+        let part = match PK::from_slice(&zero_array) {
+            Ok(part) => part,
+            Err(_) => {
+                // If creation fails, handle the error (e.g., log an error message or panic)
+                panic!("Error creating PK instance from zero-initialized array");
+            }
+        };
+
+        Self {
+            channel_id: ChannelId::default(),
+            part: part,
+            receiver: AccountId::default(),
+        }
+    }
+}
+
 
 #[derive(Encode, Decode, Default, Copy, Clone, PartialEq, RuntimeDebug)]
 #[codec(dumb_trait_bound)]

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -68,7 +68,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	//TODO: benchmark weight and replace constant
 	fn progress<U: Config>(params: &ParamsOf<U>) -> Weight {
-		return Weight::from_all(10_000).saturating_add(U::AppRegistry::transition_weight(params));
+		Weight::from_all(10_000).saturating_add(U::AppRegistry::transition_weight(params))
 	}
 	// Storage: PerunModule StateRegister (r:1 w:1)
 	// Storage: PerunModule Deposits (r:2 w:2)
@@ -83,7 +83,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	//TODO: benchmark weight and replace constant
 	fn conclude_final(_p: u32, ) -> Weight {
-		return Weight::from_all(10_000);
+		Weight::from_all(10_000)
 	}
 	// Storage: PerunModule StateRegister (r:1 w:0)
 	// Storage: PerunModule Deposits (r:1 w:1)
@@ -115,7 +115,7 @@ impl WeightInfo for () {
 	}
 	//TODO: benchmark weight and replace constant
 	fn progress<U: Config>(params: &ParamsOf<U>) -> Weight {
-		return Weight::from_all(10_000).saturating_add(U::AppRegistry::transition_weight(params));
+		Weight::from_all(10_000).saturating_add(U::AppRegistry::transition_weight(params))
 	}
 	// Storage: PerunModule StateRegister (r:1 w:1)
 	// Storage: PerunModule Deposits (r:2 w:2)
@@ -130,7 +130,7 @@ impl WeightInfo for () {
 	}
 	//TODO: benchmark weight and replace constant
 	fn conclude_final(_p: u32) -> Weight {
-		return Weight::from_all(10_000);
+		Weight::from_all(10_000)
 	}
 	// Storage: PerunModule StateRegister (r:1 w:0)
 	// Storage: PerunModule Deposits (r:1 w:1)

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -53,45 +53,45 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: PerunModule Deposits (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn deposit() -> Weight {
-		(110_609_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		(Weight::from_all(110_609_000))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
 	}
 	// Storage: Timestamp Now (r:1 w:0)
 	// Storage: PerunModule StateRegister (r:1 w:1)
 	fn dispute(p: u32, ) -> Weight {
-		(1_396_000 as Weight)
+		(Weight::from_all(1_396_000))
 			// Standard Error: 25_000
-			.saturating_add((87_897_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add((Weight::from_all(87_897_000)).saturating_mul(p.into()))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	//TODO: benchmark weight and replace constant
 	fn progress<U: Config>(params: &ParamsOf<U>) -> Weight {
-		return 10_000 + U::AppRegistry::transition_weight(params);
+		return Weight::from_all(10_000).saturating_add(U::AppRegistry::transition_weight(params));
 	}
 	// Storage: PerunModule StateRegister (r:1 w:1)
 	// Storage: PerunModule Deposits (r:2 w:2)
 	fn conclude(p: u32, ) -> Weight {
-		(17_600_000 as Weight)
+		(Weight::from_all(17_600_000))
 			// Standard Error: 426_000
-			.saturating_add((97_182_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(p as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+			.saturating_add((Weight::from_all(97_182_000)).saturating_mul(p.into()))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(p.into())))
+			.saturating_add(T::DbWeight::get().writes(1))
+			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
 	}
 	//TODO: benchmark weight and replace constant
 	fn conclude_final(_p: u32, ) -> Weight {
-		return 10_000;
+		return Weight::from_all(10_000);
 	}
 	// Storage: PerunModule StateRegister (r:1 w:0)
 	// Storage: PerunModule Deposits (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn withdraw() -> Weight {
-		(151_546_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		(Weight::from_all(151_546_000))
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(2))
 	}
 }
 
@@ -100,44 +100,44 @@ impl WeightInfo for () {
 	// Storage: PerunModule Deposits (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn deposit() -> Weight {
-		(110_609_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+		(Weight::from_all(110_609_000))
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(2))
 	}
 	// Storage: Timestamp Now (r:1 w:0)
 	// Storage: PerunModule StateRegister (r:1 w:1)
 	fn dispute(p: u32, ) -> Weight {
-		(1_396_000 as Weight)
+		(Weight::from_all(1_396_000))
 			// Standard Error: 25_000
-			.saturating_add((87_897_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+			.saturating_add((Weight::from_all(87_897_000)).saturating_mul(p.into()))
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 	//TODO: benchmark weight and replace constant
 	fn progress<U: Config>(params: &ParamsOf<U>) -> Weight {
-		return 10_000 + U::AppRegistry::transition_weight(params);
+		return Weight::from_all(10_000).saturating_add(U::AppRegistry::transition_weight(params));
 	}
 	// Storage: PerunModule StateRegister (r:1 w:1)
 	// Storage: PerunModule Deposits (r:2 w:2)
 	fn conclude(p: u32, ) -> Weight {
-		(17_600_000 as Weight)
+		(Weight::from_all(17_600_000))
 			// Standard Error: 426_000
-			.saturating_add((97_182_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(p as Weight)))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
-			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+			.saturating_add((Weight::from_all(97_182_000)).saturating_mul(p.into()))
+			.saturating_add(RocksDbWeight::get().reads(1))
+			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(p.into())))
+			.saturating_add(RocksDbWeight::get().writes(1))
+			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(p.into())))
 	}
 	//TODO: benchmark weight and replace constant
 	fn conclude_final(_p: u32) -> Weight {
-		return 10_000;
+		return Weight::from_all(10_000);
 	}
 	// Storage: PerunModule StateRegister (r:1 w:0)
 	// Storage: PerunModule Deposits (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn withdraw() -> Weight {
-		(151_546_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+		(Weight::from_all(151_546_000))
+			.saturating_add(RocksDbWeight::get().reads(3))
+			.saturating_add(RocksDbWeight::get().writes(2))
 	}
 }

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -31,7 +31,7 @@ type Block = frame_system::mocking::MockBlock<Test>;
 
 // For testing the pallet, we construct a mock runtime.
 frame_support::construct_runtime!(
-	pub enum Test 
+	pub enum Test
 	{
 		System: frame_system,
 		Balances: pallet_balances,
@@ -86,10 +86,10 @@ impl pallet_balances::Config for Test {
 	type AccountStore = frame_system::Pallet<Test>;
 	type WeightInfo = ();
 
-    type RuntimeHoldReason = (); 
+	type RuntimeHoldReason = ();
 	type RuntimeFreezeReason = ();
-    type FreezeIdentifier = u64;
-    type MaxFreezes = (); 
+	type FreezeIdentifier = u64;
+	type MaxFreezes = ();
 }
 
 parameter_types! {

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -30,7 +30,7 @@ use sp_core::{crypto::*, H256};
 pub fn assert_event_deposited(funding_id: H256, amount: u64) {
 	assert_eq!(
 		last_event(),
-		Event::Perun(pallet_perun::Event::Deposited(funding_id, amount))
+		RuntimeEvent::Perun(pallet_perun::Event::Deposited(funding_id, amount))
 	);
 }
 
@@ -38,7 +38,7 @@ pub fn assert_event_deposited(funding_id: H256, amount: u64) {
 pub fn assert_event_disputed(channel_id: ChannelIdOf<Test>, state: StateOf<Test>) {
 	assert_eq!(
 		last_event(),
-		Event::Perun(pallet_perun::Event::Disputed(channel_id, state))
+		RuntimeEvent::Perun(pallet_perun::Event::Disputed(channel_id, state))
 	);
 }
 
@@ -50,7 +50,7 @@ pub fn assert_event_progressed(
 ) {
 	assert_eq!(
 		last_event(),
-		Event::Perun(pallet_perun::Event::Progressed(channel_id, version, app))
+		RuntimeEvent::Perun(pallet_perun::Event::Progressed(channel_id, version, app))
 	);
 }
 
@@ -58,7 +58,7 @@ pub fn assert_event_progressed(
 pub fn assert_event_concluded(channel_id: ChannelIdOf<Test>) {
 	assert_eq!(
 		last_event(),
-		Event::Perun(pallet_perun::Event::Concluded(channel_id))
+		RuntimeEvent::Perun(pallet_perun::Event::Concluded(channel_id))
 	);
 }
 
@@ -66,13 +66,13 @@ pub fn assert_event_concluded(channel_id: ChannelIdOf<Test>) {
 pub fn event_withdrawn(funding_id: FundingIdOf<Test>) {
 	assert_eq!(
 		last_event(),
-		Event::Perun(pallet_perun::Event::Withdrawn(funding_id))
+		RuntimeEvent::Perun(pallet_perun::Event::Withdrawn(funding_id))
 	);
 }
 
 /// Returns the last events.
 /// Panics in case that there is none.
-pub fn last_event() -> Event {
+pub fn last_event() -> RuntimeEvent {
 	System::events().pop().expect("Event list empty").event
 }
 
@@ -115,7 +115,7 @@ pub fn call_dispute(setup: &Setup, finalized: bool) -> StateOf<Test> {
 	state.finalized = finalized;
 	let sigs = sign_state(&state, &setup);
 	assert_ok!(Perun::dispute(
-		Origin::signed(setup.ids.carl),
+		RuntimeOrigin::signed(setup.ids.carl),
 		setup.params.clone(),
 		state.clone(),
 		sigs
@@ -141,12 +141,12 @@ pub fn sign_withdrawal(withdrawal: &WithdrawalOf<Test>, setup: &Setup) -> Vec<Si
 
 pub fn deposit_both(setup: &Setup) {
 	assert_ok!(Perun::deposit(
-		Origin::signed(setup.ids.alice),
+		RuntimeOrigin::signed(setup.ids.alice),
 		setup.fids.alice,
 		setup.state.balances[0]
 	));
 	assert_ok!(Perun::deposit(
-		Origin::signed(setup.ids.bob),
+		RuntimeOrigin::signed(setup.ids.bob),
 		setup.fids.bob,
 		setup.state.balances[1]
 	));

--- a/tests/conclude.rs
+++ b/tests/conclude.rs
@@ -31,7 +31,7 @@ fn conclude_final() {
 		let sigs = sign_state(&state, &setup);
 
 		assert_ok!(Perun::conclude_final(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs
@@ -47,7 +47,7 @@ fn conclude_not_final() {
 
 		assert_noop!(
 			Perun::conclude_final(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				setup.state.clone(),
 				sigs
@@ -70,7 +70,7 @@ fn conclude_invalid_part_num() {
 		for bad_sig in bad_sigs {
 			assert_noop!(
 				Perun::conclude_final(
-					Origin::signed(setup.ids.carl),
+					RuntimeOrigin::signed(setup.ids.carl),
 					setup.params.clone(),
 					state.clone(),
 					bad_sig
@@ -95,7 +95,7 @@ fn conclude_invalid_sig_nums() {
 		for bad_sig in bad_sigs {
 			assert_noop!(
 				Perun::conclude_final(
-					Origin::signed(setup.ids.carl),
+					RuntimeOrigin::signed(setup.ids.carl),
 					setup.params.clone(),
 					state.clone(),
 					bad_sig
@@ -124,7 +124,7 @@ fn conclude_invalid_sig() {
 		for sig in sigs {
 			assert_noop!(
 				Perun::conclude_final(
-					Origin::signed(setup.ids.carl),
+					RuntimeOrigin::signed(setup.ids.carl),
 					setup.params.clone(),
 					state.clone(),
 					sig,
@@ -147,7 +147,7 @@ fn conclude_invalid_channel_id() {
 
 		// Different nonce
 		assert_noop!(
-			Perun::conclude_final(Origin::signed(setup.ids.carl), params, state.clone(), sigs),
+			Perun::conclude_final(RuntimeOrigin::signed(setup.ids.carl), params, state.clone(), sigs),
 			pallet_perun::Error::<Test>::InvalidChannelId
 		);
 		assert_no_events();
@@ -163,7 +163,7 @@ fn conclude_dispute() {
 
 		increment_time(2 * setup.params.challenge_duration);
 		assert_ok!(Perun::conclude(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 		));
 		assert_event_concluded(state.channel_id);
@@ -185,7 +185,7 @@ fn conclude_progressed() {
 
 		let signer = 0;
 		assert_ok!(Perun::progress(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs[signer].clone(),
@@ -195,7 +195,7 @@ fn conclude_progressed() {
 
 		increment_time(setup.params.challenge_duration);
 		assert_ok!(Perun::conclude(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 		));
 		assert_event_concluded(state.channel_id);
@@ -218,7 +218,7 @@ fn conclude_insufficient_deposits() {
 		let alice_deposits = Perun::deposits(setup.fids.alice);
 		let bob_deposits = Perun::deposits(setup.fids.bob);
 		assert_ok!(Perun::conclude_final(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs
@@ -241,7 +241,7 @@ fn conclude_final_already_concluded() {
 		let sigs = sign_state(&state, &setup);
 
 		assert_ok!(Perun::conclude_final(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs.clone()
@@ -250,7 +250,7 @@ fn conclude_final_already_concluded() {
 		// Twice works, but no new event will be emitted.
 		let events = num_events();
 		assert_ok!(Perun::conclude_final(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs.clone()
@@ -262,7 +262,7 @@ fn conclude_final_already_concluded() {
 		let sigs = sign_state(&state, &setup);
 		assert_noop!(
 			Perun::conclude_final(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs
@@ -280,14 +280,14 @@ fn conclude_twice() {
 		increment_time(2 * setup.params.challenge_duration);
 
 		assert_ok!(Perun::conclude(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 		));
 
 		// Twice works, but no new event will be emitted.
 		let events = num_events();
 		assert_ok!(Perun::conclude(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 		));
 		assert_num_event(events);
@@ -302,7 +302,7 @@ fn conclude_too_early_app() {
 		increment_time(setup.params.challenge_duration);
 
 		assert_noop!(
-			Perun::conclude(Origin::signed(setup.ids.alice), setup.params.clone(),),
+			Perun::conclude(RuntimeOrigin::signed(setup.ids.alice), setup.params.clone(),),
 			pallet_perun::Error::<Test>::ConcludedTooEarly
 		);
 	});
@@ -316,7 +316,7 @@ fn conclude_too_early_no_app() {
 		increment_time(setup.params.challenge_duration / 2);
 
 		assert_noop!(
-			Perun::conclude(Origin::signed(setup.ids.alice), setup.params.clone(),),
+			Perun::conclude(RuntimeOrigin::signed(setup.ids.alice), setup.params.clone(),),
 			pallet_perun::Error::<Test>::ConcludedTooEarly
 		);
 	});

--- a/tests/conclude.rs
+++ b/tests/conclude.rs
@@ -147,7 +147,12 @@ fn conclude_invalid_channel_id() {
 
 		// Different nonce
 		assert_noop!(
-			Perun::conclude_final(RuntimeOrigin::signed(setup.ids.carl), params, state.clone(), sigs),
+			Perun::conclude_final(
+				RuntimeOrigin::signed(setup.ids.carl),
+				params,
+				state.clone(),
+				sigs
+			),
 			pallet_perun::Error::<Test>::InvalidChannelId
 		);
 		assert_no_events();

--- a/tests/deposit.rs
+++ b/tests/deposit.rs
@@ -29,7 +29,7 @@ fn deposit_some() {
 		assert_eq!(Balances::free_balance(setup.ids.alice), 100);
 		// Alice deposits 10.
 		assert_ok!(Perun::deposit(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.fids.alice,
 			10
 		));
@@ -49,12 +49,12 @@ fn deposit_event_absolute() {
 	run_test(MOCK_APP, |setup| {
 		// Alice deposits 10 and then 20.
 		assert_ok!(Perun::deposit(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.fids.alice,
 			10
 		));
 		assert_ok!(Perun::deposit(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.fids.alice,
 			20
 		));
@@ -79,7 +79,7 @@ fn deposit_amount_too_low() {
 		);
 		// Charlie deposits too few.
 		assert_noop!(
-			Perun::deposit(Origin::signed(setup.ids.carl), setup.fids.alice, min - 1),
+			Perun::deposit(RuntimeOrigin::signed(setup.ids.carl), setup.fids.alice, min - 1),
 			Error::<Test>::DepositTooSmall
 		);
 		// Holdings are now 0.
@@ -105,11 +105,11 @@ fn deposit_insufficient_balance() {
 		// Dora tries to deposit more than she has.
 		assert_noop!(
 			Perun::deposit(
-				Origin::signed(setup.ids.dora),
+				RuntimeOrigin::signed(setup.ids.dora),
 				setup.fids.alice,
 				PerunMinDeposit::get()
 			),
-			pallet_balances::Error::<Test>::InsufficientBalance
+			sp_runtime::TokenError::FundsUnavailable
 		);
 		// Holdings are 0.
 		assert_eq!(Perun::deposits(setup.fids.alice), None);
@@ -125,14 +125,14 @@ fn deposit_overflow() {
 	run_test(MOCK_APP, |setup| {
 		// Alice deposits 10.
 		assert_ok!(Perun::deposit(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.fids.alice,
 			10
 		));
 
 		assert_noop!(
 			Perun::deposit(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.fids.alice,
 				BalanceOf::<Test>::MAX,
 			),

--- a/tests/deposit.rs
+++ b/tests/deposit.rs
@@ -79,7 +79,11 @@ fn deposit_amount_too_low() {
 		);
 		// Charlie deposits too few.
 		assert_noop!(
-			Perun::deposit(RuntimeOrigin::signed(setup.ids.carl), setup.fids.alice, min - 1),
+			Perun::deposit(
+				RuntimeOrigin::signed(setup.ids.carl),
+				setup.fids.alice,
+				min - 1
+			),
 			Error::<Test>::DepositTooSmall
 		);
 		// Holdings are now 0.

--- a/tests/dispute.rs
+++ b/tests/dispute.rs
@@ -25,7 +25,7 @@ fn dispute_ok() {
 		let sigs = sign_state(&setup.state, &setup);
 
 		assert_ok!(Perun::dispute(
-			Origin::signed(setup.ids.carl),
+			RuntimeOrigin::signed(setup.ids.carl),
 			setup.params.clone(),
 			setup.state.clone(),
 			sigs
@@ -44,7 +44,7 @@ fn dispute_final() {
 
 		assert_noop!(
 			Perun::dispute(
-				Origin::signed(setup.ids.carl),
+				RuntimeOrigin::signed(setup.ids.carl),
 				setup.params.clone(),
 				state,
 				sigs
@@ -65,7 +65,7 @@ fn dispute_already_concluded() {
 		let sigs = sign_state(&state, &setup);
 
 		assert_ok!(Perun::conclude_final(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs.clone()
@@ -74,7 +74,7 @@ fn dispute_already_concluded() {
 		let sigs = sign_state(&setup.state, &setup);
 		assert_noop!(
 			Perun::dispute(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				setup.state.clone(),
 				sigs
@@ -95,7 +95,7 @@ fn dispute_challenge_duration_overflow() {
 
 		increment_time(1);
 		assert_noop!(
-			Perun::dispute(Origin::signed(setup.ids.carl), params, state, sigs),
+			Perun::dispute(RuntimeOrigin::signed(setup.ids.carl), params, state, sigs),
 			pallet_perun::Error::<Test>::ChallengeDurationOverflow
 		);
 		assert_no_events();
@@ -111,7 +111,7 @@ fn dispute_invalid_part_num() {
 		for bad_sig in bad_sigs {
 			assert_noop!(
 				Perun::dispute(
-					Origin::signed(setup.ids.carl),
+					RuntimeOrigin::signed(setup.ids.carl),
 					setup.params.clone(),
 					setup.state.clone(),
 					bad_sig
@@ -134,7 +134,7 @@ fn dispute_invalid_sig_nums() {
 		for bad_sig in bad_sigs {
 			assert_noop!(
 				Perun::dispute(
-					Origin::signed(setup.ids.carl),
+					RuntimeOrigin::signed(setup.ids.carl),
 					setup.params.clone(),
 					setup.state.clone(),
 					bad_sig
@@ -162,7 +162,7 @@ fn dispute_invalid_sig() {
 		for sig in sigs {
 			assert_noop!(
 				Perun::dispute(
-					Origin::signed(setup.ids.carl),
+					RuntimeOrigin::signed(setup.ids.carl),
 					setup.params.clone(),
 					setup.state.clone(),
 					sig,
@@ -184,7 +184,7 @@ fn dispute_invalid_channel_id() {
 		// Different nonce
 		assert_noop!(
 			Perun::dispute(
-				Origin::signed(setup.ids.carl),
+				RuntimeOrigin::signed(setup.ids.carl),
 				params,
 				setup.state.clone(),
 				sigs,
@@ -201,7 +201,7 @@ fn dispute_invalid_channel_id() {
 		// Different parts
 		assert_noop!(
 			Perun::dispute(
-				Origin::signed(setup.ids.carl),
+				RuntimeOrigin::signed(setup.ids.carl),
 				params,
 				setup.state.clone(),
 				sigs,
@@ -218,7 +218,7 @@ fn dispute_invalid_channel_id() {
 		// Different challenge duration
 		assert_noop!(
 			Perun::dispute(
-				Origin::signed(setup.ids.carl),
+				RuntimeOrigin::signed(setup.ids.carl),
 				params,
 				setup.state.clone(),
 				sigs,
@@ -235,7 +235,7 @@ fn dispute_invalid_channel_id() {
 		// Different Channel ID in State
 		assert_noop!(
 			Perun::dispute(
-				Origin::signed(setup.ids.carl),
+				RuntimeOrigin::signed(setup.ids.carl),
 				setup.params.clone(),
 				state.clone(),
 				sigs,
@@ -256,7 +256,7 @@ fn dispute_same_version() {
 		let sigs = sign_state(&setup.state, &setup);
 		assert_noop!(
 			Perun::dispute(
-				Origin::signed(setup.ids.carl),
+				RuntimeOrigin::signed(setup.ids.carl),
 				setup.params.clone(),
 				setup.state.clone(),
 				sigs
@@ -281,7 +281,7 @@ fn dispute_higher_version() {
 			let sigs = sign_state(&state, &setup);
 
 			assert_ok!(Perun::dispute(
-				Origin::signed(setup.ids.carl),
+				RuntimeOrigin::signed(setup.ids.carl),
 				setup.params.clone(),
 				state.clone(),
 				sigs
@@ -307,7 +307,7 @@ fn dispute_timeout() {
 
 			assert_noop!(
 				Perun::dispute(
-					Origin::signed(setup.ids.carl),
+					RuntimeOrigin::signed(setup.ids.carl),
 					setup.params.clone(),
 					state.clone(),
 					sigs

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -36,7 +36,7 @@ fn progress() {
 
 		let signer = 0;
 		assert_ok!(Perun::progress(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs[signer].clone(),
@@ -62,7 +62,7 @@ fn progress_no_app() {
 		let signer = 0;
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),
@@ -90,7 +90,7 @@ fn progress_invalid_signature() {
 		let not_signer = 1;
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),
@@ -116,7 +116,7 @@ fn progress_invalid_version() {
 		let signer = 0;
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),
@@ -144,7 +144,7 @@ fn progress_invalid_balances() {
 		let signer = 0;
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),
@@ -171,7 +171,7 @@ fn progress_final() {
 
 		let signer = 0;
 		assert_ok!(Perun::progress(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs[signer].clone(),
@@ -185,7 +185,7 @@ fn progress_final() {
 		let signer = 0;
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),
@@ -214,7 +214,7 @@ fn progress_invalid_app_transition() {
 		let signer = 0;
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),
@@ -241,7 +241,7 @@ fn progress_too_early() {
 		let signer = 0;
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),
@@ -267,7 +267,7 @@ fn progress_already_concluded() {
 		let signer = 0;
 
 		assert_ok!(Perun::progress(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs[signer].clone(),
@@ -278,7 +278,7 @@ fn progress_already_concluded() {
 		increment_time(setup.params.challenge_duration);
 
 		assert_ok!(Perun::conclude(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 		));
 		assert_event_concluded(state.channel_id);
@@ -287,7 +287,7 @@ fn progress_already_concluded() {
 		let sigs = sign_state(&state, &setup);
 		assert_noop!(
 			Perun::progress(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				setup.params.clone(),
 				state.clone(),
 				sigs[signer].clone(),

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -41,8 +41,15 @@ fn push_outcome_invalid_parts() {
 #[cfg(feature = "expose_privates")]
 #[test]
 fn push_outcome_invalid_outcome() {
+    use pallet_perun::types::PkOf;
+
 	run_test(MOCK_APP, |setup| {
-		let parts: Vec<PkOf<Test>> = vec![Default::default(); 2];
+		let mut parts = Vec::new();
+		for _ in 0..2 {
+			let zero = vec![0; 33];
+			let pk_instance = PkOf::<Test>::from_full(&zero).expect("Failed to create PkOf instance");
+			parts.push(pk_instance);
+		}
 		let bals: Vec<BalanceOf<Test>> = vec![BalanceOf::<Test>::MAX, 1];
 
 		assert_noop!(
@@ -69,14 +76,15 @@ fn time_now() {
 fn unsigned_tx() {
 	run_test(MOCK_APP, |_| {
 		assert_noop!(
-			Perun::deposit(Origin::none(), Default::default(), Default::default()),
+			Perun::deposit(RuntimeOrigin::none(), Default::default(), Default::default()),
 			BadOrigin
 		);
 	});
+
 	run_test(MOCK_APP, |_| {
 		assert_noop!(
 			Perun::dispute(
-				Origin::none(),
+				RuntimeOrigin::none(),
 				Default::default(),
 				Default::default(),
 				Default::default()
@@ -86,14 +94,14 @@ fn unsigned_tx() {
 	});
 	run_test(MOCK_APP, |_| {
 		assert_noop!(
-			Perun::conclude(Origin::none(), Default::default(),),
+			Perun::conclude(RuntimeOrigin::none(), Default::default(),),
 			BadOrigin
 		);
 	});
 	run_test(MOCK_APP, |_| {
 		assert_noop!(
 			Perun::conclude_final(
-				Origin::none(),
+				RuntimeOrigin::none(),
 				Default::default(),
 				Default::default(),
 				Default::default()
@@ -103,7 +111,7 @@ fn unsigned_tx() {
 	});
 	run_test(MOCK_APP, |_| {
 		assert_noop!(
-			Perun::withdraw(Origin::none(), Default::default(), Default::default()),
+			Perun::withdraw(RuntimeOrigin::none(), Default::default(), Default::default()),
 			BadOrigin
 		);
 	});

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -41,13 +41,14 @@ fn push_outcome_invalid_parts() {
 #[cfg(feature = "expose_privates")]
 #[test]
 fn push_outcome_invalid_outcome() {
-    use pallet_perun::types::PkOf;
+	use pallet_perun::types::PkOf;
 
 	run_test(MOCK_APP, |setup| {
 		let mut parts = Vec::new();
 		for _ in 0..2 {
 			let zero = vec![0; 33];
-			let pk_instance = PkOf::<Test>::from_full(&zero).expect("Failed to create PkOf instance");
+			let pk_instance =
+				PkOf::<Test>::from_full(&zero).expect("Failed to create PkOf instance");
 			parts.push(pk_instance);
 		}
 		let bals: Vec<BalanceOf<Test>> = vec![BalanceOf::<Test>::MAX, 1];
@@ -76,7 +77,11 @@ fn time_now() {
 fn unsigned_tx() {
 	run_test(MOCK_APP, |_| {
 		assert_noop!(
-			Perun::deposit(RuntimeOrigin::none(), Default::default(), Default::default()),
+			Perun::deposit(
+				RuntimeOrigin::none(),
+				Default::default(),
+				Default::default()
+			),
 			BadOrigin
 		);
 	});
@@ -111,7 +116,11 @@ fn unsigned_tx() {
 	});
 	run_test(MOCK_APP, |_| {
 		assert_noop!(
-			Perun::withdraw(RuntimeOrigin::none(), Default::default(), Default::default()),
+			Perun::withdraw(
+				RuntimeOrigin::none(),
+				Default::default(),
+				Default::default()
+			),
 			BadOrigin
 		);
 	});

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -46,13 +46,7 @@ fn push_outcome_invalid_outcome() {
 	run_test(MOCK_APP, |setup| {
 		let mut parts = Vec::new();
 		for _ in 0..2 {
-			let zero = vec![0; 33];
-			let zero_slice: [u8; 33] = {
-				// Create an array of exactly 33 elements by converting the Vec<u8> to an array
-				let mut array = [0; 33];
-				array.copy_from_slice(&zero[..33]); // Copy the first 33 elements of zero into the array
-				array
-			};
+			let zero_slice = [0u8; 33];
 			let pk_instance = PkOf::<Test>::from_raw(zero_slice);
 			parts.push(pk_instance);
 		}

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -47,8 +47,13 @@ fn push_outcome_invalid_outcome() {
 		let mut parts = Vec::new();
 		for _ in 0..2 {
 			let zero = vec![0; 33];
-			let pk_instance =
-				PkOf::<Test>::from_full(&zero).expect("Failed to create PkOf instance");
+			let zero_slice: [u8; 33] = {
+				// Create an array of exactly 33 elements by converting the Vec<u8> to an array
+				let mut array = [0; 33];
+				array.copy_from_slice(&zero[..33]); // Copy the first 33 elements of zero into the array
+				array
+			};
+			let pk_instance = PkOf::<Test>::from_raw(zero_slice);
 			parts.push(pk_instance);
 		}
 		let bals: Vec<BalanceOf<Test>> = vec![BalanceOf::<Test>::MAX, 1];

--- a/tests/withdraw.rs
+++ b/tests/withdraw.rs
@@ -32,7 +32,7 @@ fn withdraw_invalid_sig() {
 
 		assert_noop!(
 			Perun::withdraw(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				withdrawal,
 				Default::default()
 			),
@@ -52,7 +52,7 @@ fn withdraw_unknown_channel() {
 		let sigs = sign_withdrawal(&withdrawal, setup);
 
 		assert_noop!(
-			Perun::withdraw(Origin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
+			Perun::withdraw(RuntimeOrigin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
 			pallet_perun::Error::<Test>::UnknownChannel
 		);
 	});
@@ -72,7 +72,7 @@ fn withdraw_not_concluded() {
 		let sigs = sign_withdrawal(&withdrawal, setup);
 
 		assert_noop!(
-			Perun::withdraw(Origin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
+			Perun::withdraw(RuntimeOrigin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
 			pallet_perun::Error::<Test>::NotConcluded
 		);
 	});
@@ -86,7 +86,7 @@ fn withdraw_unknown_participant() {
 		state.balances = vec![0, 0];
 		let sigs = sign_state(&state, &setup);
 		assert_ok!(Perun::conclude_final(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs
@@ -102,7 +102,7 @@ fn withdraw_unknown_participant() {
 
 		assert_noop!(
 			Perun::withdraw(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				withdrawal,
 				sig_carl.clone()
 			),
@@ -128,7 +128,7 @@ fn withdraw_ok() {
 		let sigs = sign_state(&state, &setup);
 
 		assert_ok!(Perun::conclude_final(
-			Origin::signed(setup.ids.alice),
+			RuntimeOrigin::signed(setup.ids.alice),
 			setup.params.clone(),
 			state.clone(),
 			sigs
@@ -144,7 +144,7 @@ fn withdraw_ok() {
 			let sigs = sign_withdrawal(&withdrawal, setup);
 
 			assert_ok!(Perun::withdraw(
-				Origin::signed(setup.ids.alice),
+				RuntimeOrigin::signed(setup.ids.alice),
 				withdrawal.clone(),
 				sigs[0].clone()
 			),);
@@ -153,7 +153,7 @@ fn withdraw_ok() {
 			assert_eq!(Balances::free_balance(setup.ids.alice), 95);
 			// Withdrawing twice errors.
 			assert_noop!(
-				Perun::withdraw(Origin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
+				Perun::withdraw(RuntimeOrigin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
 				pallet_perun::Error::<Test>::UnknownDeposit
 			);
 		}
@@ -167,7 +167,7 @@ fn withdraw_ok() {
 			let sigs = sign_withdrawal(&withdrawal, setup);
 
 			assert_ok!(Perun::withdraw(
-				Origin::signed(setup.ids.bob),
+				RuntimeOrigin::signed(setup.ids.bob),
 				withdrawal.clone(),
 				sigs[1].clone()
 			),);
@@ -176,7 +176,7 @@ fn withdraw_ok() {
 			assert_eq!(Balances::free_balance(setup.ids.bob), 105);
 			// Withdrawing twice errors.
 			assert_noop!(
-				Perun::withdraw(Origin::signed(setup.ids.bob), withdrawal, sigs[1].clone()),
+				Perun::withdraw(RuntimeOrigin::signed(setup.ids.bob), withdrawal, sigs[1].clone()),
 				pallet_perun::Error::<Test>::UnknownDeposit
 			);
 		}

--- a/tests/withdraw.rs
+++ b/tests/withdraw.rs
@@ -52,7 +52,11 @@ fn withdraw_unknown_channel() {
 		let sigs = sign_withdrawal(&withdrawal, setup);
 
 		assert_noop!(
-			Perun::withdraw(RuntimeOrigin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
+			Perun::withdraw(
+				RuntimeOrigin::signed(setup.ids.alice),
+				withdrawal,
+				sigs[0].clone()
+			),
 			pallet_perun::Error::<Test>::UnknownChannel
 		);
 	});
@@ -72,7 +76,11 @@ fn withdraw_not_concluded() {
 		let sigs = sign_withdrawal(&withdrawal, setup);
 
 		assert_noop!(
-			Perun::withdraw(RuntimeOrigin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
+			Perun::withdraw(
+				RuntimeOrigin::signed(setup.ids.alice),
+				withdrawal,
+				sigs[0].clone()
+			),
 			pallet_perun::Error::<Test>::NotConcluded
 		);
 	});
@@ -153,7 +161,11 @@ fn withdraw_ok() {
 			assert_eq!(Balances::free_balance(setup.ids.alice), 95);
 			// Withdrawing twice errors.
 			assert_noop!(
-				Perun::withdraw(RuntimeOrigin::signed(setup.ids.alice), withdrawal, sigs[0].clone()),
+				Perun::withdraw(
+					RuntimeOrigin::signed(setup.ids.alice),
+					withdrawal,
+					sigs[0].clone()
+				),
 				pallet_perun::Error::<Test>::UnknownDeposit
 			);
 		}
@@ -176,7 +188,11 @@ fn withdraw_ok() {
 			assert_eq!(Balances::free_balance(setup.ids.bob), 105);
 			// Withdrawing twice errors.
 			assert_noop!(
-				Perun::withdraw(RuntimeOrigin::signed(setup.ids.bob), withdrawal, sigs[1].clone()),
+				Perun::withdraw(
+					RuntimeOrigin::signed(setup.ids.bob),
+					withdrawal,
+					sigs[1].clone()
+				),
 				pallet_perun::Error::<Test>::UnknownDeposit
 			);
 		}


### PR DESCRIPTION

This pull request updates the Substrate SDK version to Polkadot v1.9. By incorporating the latest Polkadot release (v1.9)

As reference: https://github.com/substrate-developer-hub/substrate-node-template

Changes made:
- Update dependencies in `Cargo.toml`
- Remove outdated interfaces `Default` for PK and add interface `TypeInfo` requirement in `types.rs`
- Change required attributes in `src/lib.rs` (ex: `Event` to `RuntimeEvent` + add `#[pallet::without_storage_info]` for struct to specified unknown `MaxEncodedLen` parameters, add explicit call_index for each call).
- Change `weight.rs` conversion from int to fit the new Weight package
- In `test`, change expected error from `InsufficientBalance` to `FundsUnvailabe` for the case insufficient depositing.

**Important**: This PR must be reviewed first before reviewing the PR from Perun-Polkadot-Node because the Node uses a submodule of pallet inside. 